### PR TITLE
Specify numpy version prevents error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,3 +16,4 @@ dependencies:
   - pip
   - pip:
     - catfishq
+    - numpy==1.19.5


### PR DESCRIPTION
Numpy Error:
https://github.com/nanoporetech/pipeline-umi-amplicon/issues/13

Solution (Downgrade Numpy):
https://github.com/nanoporetech/pipeline-umi-amplicon/issues/13#issuecomment-963881500

With reference to the above; proposal to include (numpy==1.19.5) as otherwise numpy will default to (numpy-base-1.21.2    | 4.8 MB    | ) when installed using provided conda instructions which errors.