### PR TITLE
added bedtools to dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - samtools
   - seqkit
   - pysam
+  - bedtools
   - vsearch
   - varscan
   - medaka==1.1.3


### PR DESCRIPTION
Bedtools is required for snakefile rule all and rule variants (currently misspelled varaints), but never installed.
I added the dependency for Conda to install it.