### PR TITLE
Update environment.yml to python 3.10.8 to enable install of medaka 3.10

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python==3.8.16
+  - python==3.10.8
   - snakemake
   - minimap2
   - samtools


### PR DESCRIPTION
Updated the python version in environment.yml to allow install of newer medaka versions.