### PR TITLE
Smolecule fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The pipeline performs the following steps:
 The following software packages must be installed prior to running:
 
 -  [miniconda3](https://conda.io/miniconda.html) - please refer to installation [instructions](https://conda.io/projects/conda/en/latest/user-guide/install/index.html).
+- [Apptainer](https://apptainer.org/) - please refer to installation [instructions](https://apptainer.org/docs/admin/1.3/installation.html#install-from-pre-built-packages). *The pipeline was tested and worked with a local installation of Apptainer version 1.3.2*.
 
 ### Installation
 After installing miniconda3, install the pipeline as follows:
@@ -41,7 +42,7 @@ conda activate pipeline-umi-amplicon
 cd lib && pip install . && cd ..
 
 # To test if the installation was successful run
-snakemake -j 1 -pr --configfile config.yml
+snakemake -j 1 -pr --configfile config.yml --use-singularity --singularity-args=--cleanenv
 # Deactivate environment
 conda deactivate
 ```
@@ -78,7 +79,7 @@ After the a pipeline analysis has completed, the aligned reads can be found at `
 To run the pipeline with default settings invoke snakemake as follows.
 
 ```bash
-$ snakemake -j 30 reads --configfile config.yml
+$ snakemake -j 30 reads --configfile config.yml --use-singularity --singularity-args=--cleanenv
 ```
 
 `-j` specifies how many CPU cores will be used by the pipeline. `reads` is the default target (see Targets); this will run all steps required to produce aligned high accuracy consensus reads. Please see the example config files for the required parameters.

--- a/Snakefile
+++ b/Snakefile
@@ -276,7 +276,7 @@ rule polish_clusters:
     shell:
         """
         rm -rf {output.FOLDER}
-        medaka smolecule --threads {threads} --length 50 --depth 2 --model {params.medaka_model} --method spoa {input.I2} {output.FOLDER} 2> {output.BAM}_smolecule.log
+        medaka smolecule --threads {threads} --length 50 --depth 2 --model {params.medaka_model} --method spoa {output.FOLDER} {input.I2} 2> {output.BAM}_smolecule.log
         cp {output.FOLDER}/consensus.fasta {output.F}
         cp {output.FOLDER}/subreads_to_spoa.bam {output.BAM} && cp {output.FOLDER}/subreads_to_spoa.bam.bai {output.BAM}.bai
         """

--- a/Snakefile
+++ b/Snakefile
@@ -272,6 +272,8 @@ rule polish_clusters:
         F = "{name}/fasta/{target}_consensus.fasta"
     params:
         medaka_model = mm
+    container:
+    	"docker://ontresearch/medaka:v1.11.3"
     threads: 30
     shell:
         """

--- a/Snakefile
+++ b/Snakefile
@@ -47,6 +47,7 @@ min_length = config.get("min_length", 40)
 max_length = config.get("max_length", 60)
 filter_reads = config.get("filter_reads", False)
 min_read_len = config.get("min_read_len", 100)
+max_read_len = config.get("max_read_len", 5000)
 min_mean_qual = config.get("min_mean_qual", 70)
 varscan_params = config.get("varscan_params", '--variants 1 --output-vcf 1 --min-coverage 8 --min-avg-qual 0 --min-var-freq 0.01 --strand-filter 0 --p-value 1 --min-reads2 2')
 
@@ -120,7 +121,7 @@ rule filter_reads:
         
         if [[ {params.filter_reads} == "True" ]]
         then
-            filtlong --min_length {params.min_read_len} --min_mean_q {params.min_mean_qual} {input.FQ} | gzip > {output.FQ}
+            filtlong --min_length {params.min_read_len} --max_length {params.max_read_len} --min_mean_q {params.min_mean_qual} {input.FQ} | gzip > {output.FQ}
             printf 'Total reads in file post filtering: ' 2>&1 | tee {output.STATS}
             zcat {output.FQ} | echo $((`wc -l`/4)) 2>&1 | tee {output.STATS}
         else

--- a/Snakefile
+++ b/Snakefile
@@ -103,6 +103,7 @@ rule filter_reads:
         FQ = input_folder
     params:
         min_read_len = min_read_len,
+        max_read_len = max_read_len,
         min_mean_qual = min_mean_qual,
         filter_reads = filter_reads
     output:

--- a/config-example.yml
+++ b/config-example.yml
@@ -1,14 +1,14 @@
 # Name of output folder
-sample_name: "sample"
+sample_name: example_egfr_single_read_run
 
 # Input FASTQ files. Can be a (zipped) FASTQ file or a folder containing (zipped) FASTQ files
-input_fastq: "file.fastq"
+input_fastq: data/example_egfr_single_cluster.fastq
 
 # Reference genome
-reference_fasta: "RefSeq_GRCh38.p14/GCA_000001405.15_GRCh38_no_alt_analysis_set_masked.fasta"
+reference_fasta: "data/example_egfr_reference.fasta"
 
 # BED file containing intervals with regions that are going to be analysed
-targets_bed: "file.bed"
+targets_bed: data/example_egfr_amplicon.bed
 
 
 ############################
@@ -19,10 +19,10 @@ targets_bed: "file.bed"
 umi_errors: 3
 
 # Min number of reads required for a consensus read
-min_reads_per_cluster: 5
+min_reads_per_cluster: 20
 
 # Max number of 1D used for a consensus read
-max_reads_per_cluster: 80
+max_reads_per_cluster: 60
 
 # Min overlap with target region
 min_overlap: 0.90
@@ -31,7 +31,7 @@ min_overlap: 0.90
 balance_strands: True
 
 # Medaka model used to compute consensus reads (default = "r1041_e82_400bps_sup_v4.3.0")
-medaka_model: "r1041_e82_400bps_sup_v4.3.0"
+medaka_model: "r941_min_high_g360"
 
 # Forward tail of primer (Ftail...UMI...primer)
 fwd_context: "GTATCGTGTAGAGACTGCGTAGG"
@@ -49,16 +49,13 @@ rev_umi: "AAABBBBAABBBBAABBBBAABBBBAAA"
 min_length: 40
 
 # Maximum combined UMI length
-max_length: 75
+max_length: 60
 
 # should the fastq reads be length and quality filtered?
 filter_reads: False
 
 # fastq min read length (if filter_reads is set to true)
-min_read_len: 2000
-
-# fastq min read length (if filter_reads is set to true)
-max_read_len: 4000
+min_read_len: 100
 
 # fastq min mean read quality score (if filter_reads is set to true)
 min_mean_qual: 70

--- a/config.yml
+++ b/config.yml
@@ -30,7 +30,7 @@ min_overlap: 0.90
 # Balance forward and reverse 1D reads in clusters
 balance_strands: True
 
-# Medaka model used to compute consensus reads
+# Medaka model used to compute consensus reads (default = "r1041_e82_400bps_sup_v4.3.0")
 medaka_model: "r941_min_high_g360"
 
 # Forward tail of primer (Ftail...UMI...primer)

--- a/environment.yml
+++ b/environment.yml
@@ -16,5 +16,6 @@ dependencies:
   - varscan
   - medaka
   - pip
+  - filtlong
   - pip:
     - catfishq


### PR DESCRIPTION
Fixes:
* Installation of Filtlong from bioconda,
* Syntax for the `medaka smolecule` command in the rule `polish_clusters`: order of the positional arguments with Medaka v1.11.3,
* Containerized the rule `polish_clusters` with Docker image pulled into Apptainer to ensure Medaka v1.11.3 is used: Medaka v2.0 is installed with bioconda since 2024, Sep 17 and this version is not compatible with `smolecule` as it is used in the` pipeline-umi-amplicon`. 